### PR TITLE
Feature/58635 (Context)

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -1,7 +1,7 @@
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import { createServer } from 'http';
-import { UserAPI } from './datasource/index';
+import { UserAPI, TraineeAPI } from './datasource/index';
 
 class Server {
   constructor(config) {
@@ -28,7 +28,14 @@ class Server {
       ...schema,
       dataSources: () => {
         const userAPI = new UserAPI();
-        return { userAPI };
+        const traineeAPI = new TraineeAPI();
+        return { userAPI, traineeAPI };
+      },
+      context: ({ req }) => {
+        if (req) {
+          return { token: req.headers.authorization };
+        }
+        return {};
       }
     });
     this.Server.applyMiddleware({ app });

--- a/src/Server.js
+++ b/src/Server.js
@@ -26,11 +26,10 @@ class Server {
     const { app } = this;
     this.Server = new ApolloServer({
       ...schema,
-      dataSources: () => {
-        const userAPI = new UserAPI();
-        const traineeAPI = new TraineeAPI();
-        return { userAPI, traineeAPI };
-      },
+      dataSources: () => ({
+        userAPI: new UserAPI(),
+        traineeAPI: new TraineeAPI()
+      }),
       context: ({ req }) => {
         if (req) {
           return { token: req.headers.authorization };

--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -1,0 +1,29 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+import config from '../config/configurations';
+
+export default class TraineeAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = `${config.SERVICE_URL}/api`;
+  }
+
+  willSendRequest(request) {
+    request.headers.set('Authorization', this.context.token);
+  }
+
+  getTrainees() {
+    return this.get('/trainee');
+  }
+
+  createTrainee(payload) {
+    return this.post('/trainee', payload);
+  }
+
+  updateTrainee(payload) {
+    return this.put('/trainee', payload);
+  }
+
+  deleteTrainee(payload) {
+    return this.delete('/trainee', payload);
+  }
+}

--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -23,7 +23,7 @@ export default class TraineeAPI extends RESTDataSource {
     return this.put('/trainee', payload);
   }
 
-  deleteTrainee(payload) {
-    return this.delete('/trainee', payload);
+  deleteTrainee(id) {
+    return this.delete(`/trainee?id=${id}`);
   }
 }

--- a/src/datasource/User.js
+++ b/src/datasource/User.js
@@ -7,6 +7,10 @@ export default class UserAPI extends RESTDataSource {
     this.baseURL = `${config.SERVICE_URL}/api/user`;
   }
 
+  willSendRequest(request) {
+    request.headers.set('Authorization', this.context.token);
+  }
+
   getMe() {
     return this.get('/me');
   }

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -5,9 +5,9 @@ type Query {
 }
 
 type Mutation {
-    createTrainee(user: CreateUserInput): User!
-    updateTrainee(user: UpdateUserInput): User!
-    deleteTrainee(id:ID!): ID!
+    createTrainee(payload: CreateUserInput): String!
+    updateTrainee(payload: UpdateUserInput): String!
+    deleteTrainee(payload: Deletetrainee): ID!
     loginUser(payload: LoginInput): String!
 }
 

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -7,7 +7,7 @@ type Query {
 type Mutation {
     createTrainee(payload: CreateUserInput): String!
     updateTrainee(payload: UpdateUserInput): String!
-    deleteTrainee(payload: Deletetrainee): ID!
+    deleteTrainee(payload: Deletetrainee): String!
     loginUser(payload: LoginInput): String!
 }
 

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -5,10 +5,10 @@ export default {
   createTrainee: async (parent, args, context) => {
     const { payload: { email, name, password } } = args;
     const { dataSources: { traineeAPI } } = context;
-    const addedUser = await traineeAPI.createTrainee({ email, name, password });
-    pubsub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: addedUser });
-    const addedUserData = JSON.stringify(addedUser.data);
-    return addedUserData;
+    const addedTrainee = await traineeAPI.createTrainee({ email, name, password });
+    const addedTraineeData = JSON.stringify(addedTrainee.data);
+    pubsub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: addedTrainee.data });
+    return addedTraineeData;
   },
   updateTrainee: async (parent, args, context) => {
     const {
@@ -17,12 +17,12 @@ export default {
       }
     } = args;
     const { dataSources: { traineeAPI } } = context;
-    const updatedUser = await traineeAPI.updateTrainee({
+    const updatedTrainee = await traineeAPI.updateTrainee({
       id, name, email, role, password
     });
-    pubsub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedUser });
-    const UpdateUserData = JSON.stringify(updatedUser.data);
-    return UpdateUserData;
+    const updatedTraineeData = JSON.stringify(updatedTrainee.data);
+    pubsub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedTrainee.data });
+    return updatedTraineeData;
   },
   deleteTrainee: async (parent, args, context) => {
     const {
@@ -30,7 +30,8 @@ export default {
     } = args;
     const { dataSources: { traineeAPI } } = context;
     const deletedID = await traineeAPI.deleteTrainee(id);
-    pubsub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedID });
-    return deletedID;
+    const deletedTraineeData = JSON.stringify(deletedID);
+    pubsub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedTraineeData });
+    return deletedTraineeData;
   }
 };

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,25 +1,35 @@
-import userInstance from '../../service/user';
 import pubsub from '../pubsub';
 import constant from '../../lib/constant';
 
 export default {
-  createTrainee: (parent, args, context) => {
-    const { user } = args;
-    const addedUser = userInstance.createUser(user);
+  createTrainee: async (parent, args, context) => {
+    const { payload: { email, name, password } } = args;
+    const { dataSources: { traineeAPI } } = context;
+    const addedUser = await traineeAPI.createTrainee({ email, name, password });
     pubsub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: addedUser });
-    return addedUser;
+    const addedUserData = JSON.stringify(addedUser.data);
+    return addedUserData;
   },
-  updateTrainee: (parent, args, context) => {
+  updateTrainee: async (parent, args, context) => {
     const {
-      user
+      payload: {
+        email, name, id, role, password
+      }
     } = args;
-    const updatedUser = userInstance.updateUser(user);
+    const { dataSources: { traineeAPI } } = context;
+    const updatedUser = await traineeAPI.updateTrainee({
+      id, name, email, role, password
+    });
     pubsub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedUser });
-    return updatedUser;
+    const UpdateUserData = JSON.stringify(updatedUser.data);
+    return UpdateUserData;
   },
-  deleteTrainee: (parent, args, context) => {
-    const { id } = args;
-    const deletedID = userInstance.deleteUser(id);
+  deleteTrainee: async (parent, args, context) => {
+    const {
+      payload: { id }
+    } = args;
+    const { dataSources: { traineeAPI } } = context;
+    const deletedID = await traineeAPI.deleteTrainee(id);
     pubsub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedID });
     return deletedID;
   }

--- a/src/modules/trainee/query.js
+++ b/src/modules/trainee/query.js
@@ -2,9 +2,13 @@ import user from '../../service/user';
 
 export default {
 
-  getAllTrainees: () => user.getAllUsers(),
   getTrainee: (parent, args) => {
     const { id } = args;
     return user.getUser(id);
+  },
+  getAllTrainees: async (parent, args, context) => {
+    const { dataSources: { traineeAPI } } = context;
+    const response = await traineeAPI.getTrainees();
+    return response.record;
   }
 };

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -1,7 +1,8 @@
 input CreateUserInput {
     name: String!
     email: String!
-    role: String!
+    password: String!
+    role: String
 }
 
 input UpdateUserInput {
@@ -9,9 +10,14 @@ input UpdateUserInput {
     name: String
     email: String
     role: String
+    password: String
 }
 
 input LoginInput {
     password: String!
     email: String!
+}
+
+input Deletetrainee{
+    id: ID!
 }

--- a/src/modules/user/mutation.js
+++ b/src/modules/user/mutation.js
@@ -3,6 +3,7 @@ export default {
     const { payload: { email, password } } = args;
     const { dataSources: { userAPI } } = context;
     const response = await userAPI.loginUser({ email, password });
-    return response.data;
+    const res = JSON.stringify(response);
+    return res;
   }
 };

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -1,6 +1,6 @@
 type User {
-    id: ID!
     name: String!
     email: String!
     role: String
+    password: String!
 }

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -1,6 +1,6 @@
 type User {
-    name: String!
-    email: String!
+    name: String
+    email: String
     role: String
-    password: String!
+    password: String
 }


### PR DESCRIPTION
AC
Add the trainee data source and add all the methods in there with respect to the available rest endpoints for trainees.
Update the schema of the entities with respect to the response of the above APIs.
Replace the mock implementation calls with actual API calls in your resolvers.
Steps

Add the context key in the Apollo Server instance, where you will get the token from the req header and return that token from there so that it is available in context.
Add a function in your data source willSendRequest where you will set the header of the request which you will get from the context.
Now as the last step make all changes according to the acceptance criteria.
